### PR TITLE
Support other login forms

### DIFF
--- a/plugin/src/Extension/Emailx.php
+++ b/plugin/src/Extension/Emailx.php
@@ -89,7 +89,7 @@ final class Emailx extends CMSPlugin implements SubscriberInterface
 
         $query = $this->db->getQuery(true);
 
-        $username = $this->app->input->post->get('username', false, 'RAW');
+        $username = $credentials['username'];
         $query->select('username')
             ->from('#__users')
             ->where('block = 0')


### PR DESCRIPTION
This modifications allows for support of other login forms which don't use the same name in the input field:
https://www.hikashop.com/forum/checkout/868542-how-to-login-with-email-address-not-username.html#360231